### PR TITLE
feat: allow for up to 5 icons

### DIFF
--- a/src/components/docs/card/CardDisplayFront.tsx
+++ b/src/components/docs/card/CardDisplayFront.tsx
@@ -66,6 +66,9 @@ export const CardDisplayFront: DocPageView<CardV1Type> = ({
     [
       "bottom1",
       "bottom2",
+      "bottom3",
+      "bottom4",
+      "bottom5",
       "description",
       "link",
       "linkLine2",
@@ -79,6 +82,9 @@ export const CardDisplayFront: DocPageView<CardV1Type> = ({
     ({
       bottom1,
       bottom2,
+      bottom3,
+      bottom4,
+      bottom5,
       description,
       link,
       linkLine2,
@@ -103,6 +109,27 @@ export const CardDisplayFront: DocPageView<CardV1Type> = ({
           CARD_SIZE.normal.height - bottom2.bounds.height - 25,
         );
         bottomX += bottom2.bounds.width + 15;
+      }
+      if (bottom3) {
+        bottom3.move(
+          bottomX,
+          CARD_SIZE.normal.height - bottom3.bounds.height - 25,
+        );
+        bottomX += bottom3.bounds.width + 15;
+      }
+      if (bottom4) {
+        bottom4.move(
+          bottomX,
+          CARD_SIZE.normal.height - bottom4.bounds.height - 25,
+        );
+        bottomX += bottom4.bounds.width + 15;
+      }
+      if (bottom5) {
+        bottom5.move(
+          bottomX,
+          CARD_SIZE.normal.height - bottom5.bounds.height - 25,
+        );
+        bottomX += bottom5.bounds.width + 15;
       }
       if (description) {
         description.move(
@@ -161,7 +188,7 @@ export const CardDisplayFront: DocPageView<CardV1Type> = ({
       : "https://oktech.jp"
     : docKey;
   const qrCode = useQRCode(link);
-  const { bottom1, bottom2 } = json;
+  const { bottom1, bottom2, bottom3, bottom4, bottom5 } = json;
   return (
     <BusinessCardSvg ref={ref} isCut={!showMargins} background="white">
       <style>{`
@@ -262,6 +289,24 @@ export const CardDisplayFront: DocPageView<CardV1Type> = ({
         <BottomIcon
           ref={refs.bottom2}
           value={bottom2 as keyof typeof AllIconTypes}
+        />
+      ) : null}
+      {bottom3 ? (
+        <BottomIcon
+          ref={refs.bottom3}
+          value={bottom3 as keyof typeof AllIconTypes}
+        />
+      ) : null}
+      {bottom4 ? (
+        <BottomIcon
+          ref={refs.bottom4}
+          value={bottom4 as keyof typeof AllIconTypes}
+        />
+      ) : null}
+      {bottom5 ? (
+        <BottomIcon
+          ref={refs.bottom5}
+          value={bottom5 as keyof typeof AllIconTypes}
         />
       ) : null}
     </BusinessCardSvg>

--- a/src/components/docs/card/CardForm.tsx
+++ b/src/components/docs/card/CardForm.tsx
@@ -6,12 +6,12 @@ import { SelectGroupWithLabel } from "@/components/form/SelectGroupWithLabel";
 import { ColorEnum, CountryGroups, DEFAULT_COLOR } from "@/docs/card";
 import { ColorInfo } from "@/components/docs/card/ColorInfo";
 
-export const CardForm: DocForm = () => (
+export const CardForm: DocForm = ({ data }) => (
   <>
     <fieldset>
       <legend>Front Side</legend>
       <InputWithLabel name="surname" label="Surname">
-        Enter your surname, the name you expect to be used with ”様" in your
+        Enter your surname, the name you expect to be used with "様" in your
         language.
         <br />
         Your surname is not required but strongly recommended. <br />
@@ -146,13 +146,42 @@ export const CardForm: DocForm = () => (
         </a>{" "}
         for adding new Icons that you like.
       </SelectGroupWithLabel>
-      <SelectGroupWithLabel
-        groups={CountryGroups as OptionGroup[]}
-        name="bottom2"
-        label="Icon B"
-      >
-        Additional Icon that you can use if you feel like it.
-      </SelectGroupWithLabel>
+      {data.bottom1 ? (
+        <SelectGroupWithLabel
+          groups={CountryGroups as OptionGroup[]}
+          name="bottom2"
+          label="Icon B"
+        >
+          Additional Icon that you can use if you feel like it.
+        </SelectGroupWithLabel>
+      ) : null}
+      {data.bottom2 ? (
+        <SelectGroupWithLabel
+          groups={CountryGroups as OptionGroup[]}
+          name="bottom3"
+          label="Icon C"
+        >
+          Additional Icon that you can use if you feel like it.
+        </SelectGroupWithLabel>
+      ) : null}
+      {data.bottom3 ? (
+        <SelectGroupWithLabel
+          groups={CountryGroups as OptionGroup[]}
+          name="bottom4"
+          label="Icon D"
+        >
+          Additional Icon that you can use if you feel like it.
+        </SelectGroupWithLabel>
+      ) : null}
+      {data.bottom4 ? (
+        <SelectGroupWithLabel
+          groups={CountryGroups as OptionGroup[]}
+          name="bottom5"
+          label="Icon E"
+        >
+          Additional Icon that you can use if you feel like it.
+        </SelectGroupWithLabel>
+      ) : null}
     </fieldset>
     <fieldset>
       <legend>Back Side</legend>

--- a/src/docs/card.ts
+++ b/src/docs/card.ts
@@ -21,6 +21,9 @@ const schema = z.object({
   color: z.enum(ColorEnum).default(ColorEnum.red),
   bottom1: z.enum(Object.keys(AllIconTypes)).optional(),
   bottom2: z.enum(Object.keys(AllIconTypes)).optional(),
+  bottom3: z.enum(Object.keys(AllIconTypes)).optional(),
+  bottom4: z.enum(Object.keys(AllIconTypes)).optional(),
+  bottom5: z.enum(Object.keys(AllIconTypes)).optional(),
 });
 
 export const PAGE_FRONT = { id: "front", label: "Front" } as const;


### PR DESCRIPTION
This PR adds support for up to 5 icons.
As an org with lots of people who've lived in various places in the world, it probably makes sense to allow for more than two icons (e.g. I'll personally use it to indicate 3 languages I speak).
I've set an upper limit of 5, in order to leave space for text at the bottom.

The UX isn't perfect when removing previously selected icons, but I think a reasonable user can figure it out.

One thing I'm **not** clear on, is whether existing published cards are backwards compatible or not -- any tips on how to test this?
